### PR TITLE
Fixes to get facebook-ads working on Stitch + BigQuery

### DIFF
--- a/macros/stitch/base/stitch_fb_ad_creatives.sql
+++ b/macros/stitch/base/stitch_fb_ad_creatives.sql
@@ -14,9 +14,9 @@ with base as (
         id as creative_id,
         lower(nullif(url_tags, '')) as url_tags,
         lower(coalesce(
-          nullif(object_story_spec.link_data.call_to_action.value.link, ''),
-          nullif(object_story_spec.video_data.call_to_action.value.link, ''),
-          nullif(object_story_spec.link_data.link, '')
+          nullif({{ nested_field('object_story_spec', ['link_data', 'call_to_action', 'value', 'link']) }}, ''),
+          nullif({{ nested_field('object_story_spec', ['video_data', 'call_to_action', 'value', 'link']) }}, ''),
+          nullif({{ nested_field('object_story_spec', ['link_data', 'link']) }}, '')
         )) as url
     
     from

--- a/macros/stitch/base/stitch_fb_ad_creatives.sql
+++ b/macros/stitch/base/stitch_fb_ad_creatives.sql
@@ -14,9 +14,9 @@ with base as (
         id as creative_id,
         lower(nullif(url_tags, '')) as url_tags,
         lower(coalesce(
-          nullif(object_story_spec__link_data__call_to_action__value__link, ''),
-          nullif(object_story_spec__video_data__call_to_action__value__link, ''),
-          nullif(object_story_spec__link_data__link, '')
+          nullif(object_story_spec.link_data.call_to_action.value.link, ''),
+          nullif(object_story_spec.video_data.call_to_action.value.link, ''),
+          nullif(object_story_spec.link_data.link, '')
         )) as url
     
     from

--- a/macros/stitch/base/stitch_fb_ad_creatives.sql
+++ b/macros/stitch/base/stitch_fb_ad_creatives.sql
@@ -20,7 +20,7 @@ with base as (
         )) as url
     
     from
-    {{ var('ad_creatives_table') }}
+    {{ stitch_base_table(var('ad_creatives_table')) }}
 
 ), splits as (
 

--- a/macros/stitch/base/stitch_fb_ad_insights.sql
+++ b/macros/stitch/base/stitch_fb_ad_insights.sql
@@ -9,7 +9,7 @@
 
 select
 
-    date_start::date as date_day,
+    {{ dbt_utils.date_trunc('day', 'date_start') }} as date_day,
     nullif(account_id,'') as account_id,
     nullif(account_name,'') as account_name,
     nullif(ad_id,'') as ad_id,

--- a/macros/stitch/base/stitch_fb_ad_insights.sql
+++ b/macros/stitch/base/stitch_fb_ad_insights.sql
@@ -28,7 +28,7 @@ select
     inline_post_engagement,
     unique_inline_link_clicks
 
-from {{ var('ads_insights_table') }}
+from {{ stitch_base_table(var('ads_insights_table'), ['campaign_id', 'adset_id', 'ad_id', 'date_start']) }}
 
 
 {% endmacro %}

--- a/macros/stitch/base/stitch_fb_ads.sql
+++ b/macros/stitch/base/stitch_fb_ads.sql
@@ -17,7 +17,7 @@ select distinct
     nullif(adset_id,'') as adset_id,
     nullif(campaign_id,'') as campaign_id,
     nullif(name,'') as name,
-    nullif(creative.id,'') as creative_id,
+    nullif({{ nested_field('creative', ['id']) }},'') as creative_id,
     created_time as created_at,
     updated_time as updated_at
     

--- a/macros/stitch/base/stitch_fb_ads.sql
+++ b/macros/stitch/base/stitch_fb_ads.sql
@@ -21,7 +21,7 @@ select distinct
     created_time as created_at,
     updated_time as updated_at
     
-from {{ var('ads_table') }}
+from {{ stitch_base_table(var('ads_table')) }}
 
 {% endmacro %}
 

--- a/macros/stitch/base/stitch_fb_ads.sql
+++ b/macros/stitch/base/stitch_fb_ads.sql
@@ -17,7 +17,7 @@ select distinct
     nullif(adset_id,'') as adset_id,
     nullif(campaign_id,'') as campaign_id,
     nullif(name,'') as name,
-    nullif(creative__id,'') as creative_id,
+    nullif(creative.id,'') as creative_id,
     created_time as created_at,
     updated_time as updated_at
     

--- a/macros/stitch/base/stitch_fb_ads_adsets.sql
+++ b/macros/stitch/base/stitch_fb_ads_adsets.sql
@@ -16,6 +16,6 @@ select
     created_time,
     nullif(effective_status,'') as effective_status
     
-from {{ var('adsets_table') }}
+from {{ stitch_base_table(var('adsets_table')) }}
 
 {% endmacro %}

--- a/macros/stitch/base/stitch_fb_campaigns.sql
+++ b/macros/stitch/base/stitch_fb_campaigns.sql
@@ -12,6 +12,6 @@ select
     nullif(id,'') as campaign_id,
     nullif(name,'') as name
     
-from {{ var('campaigns_table') }}
+from {{ stitch_base_table(var('campaigns_table')) }}
 
 {% endmacro %}

--- a/macros/stitch/nested_field.sql
+++ b/macros/stitch/nested_field.sql
@@ -1,0 +1,23 @@
+{% macro nested_field(field, subfields) %}
+
+    {{ adapter_macro('facebook_ads.nested_field', field, subfields) }}
+
+{% endmacro %}
+
+{% macro default__nested_field(field, subfields) %}
+
+{{field}}__{{ subfields|join('__') }}
+
+{% endmacro %}
+
+{% macro bigquery__nested_field(field, subfields) %}
+
+{{field}}.{{ subfields|join('.') }}
+
+{% endmacro %}
+
+{% macro snowflake__nested_field(field, subfields) %}
+
+{{field ~ "['" ~ subfields|join("']['") ~ "']" }} 
+
+{% endmacro %}

--- a/macros/stitch/stitch_base_table.sql
+++ b/macros/stitch/stitch_base_table.sql
@@ -1,0 +1,28 @@
+{% macro stitch_base_table(tablename, partition_fields=['id']) %}
+
+    {{ adapter_macro('facebook_ads.stitch_base_table', tablename, partition_fields) }}
+
+{% endmacro %}
+
+
+{% macro default__stitch_base_table(tablename, partition_fields=['id']) %}
+
+    {{tablename}}
+
+{% endmacro %}
+
+
+{% macro bigquery__stitch_base_table(tablename, partition_fields=['id']) %}
+
+    (select * 
+    from (
+
+        select 
+            *,
+            row_number() over (partition by {{ partition_fields|join(',') }} order by _sdc_sequence desc) = 1 as is_last_stitch_record
+        from {{tablename}}
+
+    )
+    where is_last_stitch_record = True) a
+
+{% endmacro %}

--- a/models/transform/fb_ad_insights_xf.sql
+++ b/models/transform/fb_ad_insights_xf.sql
@@ -41,8 +41,8 @@ with ads as (
     from insights
     left outer join ads
         on insights.ad_id = ads.ad_id
-        and insights.date_day >= date_trunc('day', ads.effective_from)::date
-        and (insights.date_day < date_trunc('day', ads.effective_to)::date or ads.effective_to is null)
+        and insights.date_day >= {{ dbt_utils.date_trunc('day', 'ads.effective_from') }}
+        and (insights.date_day < {{ dbt_utils.date_trunc('day', 'ads.effective_to') }} or ads.effective_to is null)
     left outer join creatives on ads.creative_id = creatives.creative_id
     left outer join campaigns on campaigns.campaign_id = insights.campaign_id
     left outer join adsets on adsets.adset_id = insights.adset_id


### PR DESCRIPTION
There were three changes required to get this working on Stitch + BigQuery:

1. Changed `::date` typecast to use `dbt_utils.date_trunc()`
2. Rather than using `__` (double underscore) to refer to nested fields, using a nested field macro instead
3. Use `stitch_base_table` macro as Stitch is append-only on BigQuery